### PR TITLE
Filter non-ascii characters from item title. 

### DIFF
--- a/resources/lib/__init__.py
+++ b/resources/lib/__init__.py
@@ -42,6 +42,7 @@ def build_contentitem(jsonitem):
         'tvshow': EpisodeItem,
         'movie': MovieItem
     }
+    jsonitem['title']=jsonitem['title'].encode('ascii','ignore').decode()
     return command[jsonitem['type']](jsonitem).returasjson()
 
 

--- a/resources/lib/menus/synced.py
+++ b/resources/lib/menus/synced.py
@@ -193,7 +193,7 @@ class SyncedMenu():
             notification(STR_ITEM_IS_ALREADY_MANAGED)
         else:
             # Add item to database
-            item = build_json_item([file, title, 'movie', None, year])
+            item = build_json_item([file, title.encode("ascii","ignore").decode(), 'movie', None, year])
             self.database.add_content_item(build_contentitem(item))
             notification('%s: %s' % (
                 STR_MOVIE_STAGED,


### PR DESCRIPTION
Moving certain files to 'managed' caused an error due to bad handling of non-ascii characters, as described at #31 
Filtering those characters removes the error, although it's just a workaround and not a proper solution. 